### PR TITLE
feat: Implement category and reminder features for sticky notes

### DIFF
--- a/front-end/components/StickyNote.tsx
+++ b/front-end/components/StickyNote.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import Draggable from 'react-draggable';
-import { X, Copy, Palette, Type, Move, MoreVertical } from 'lucide-react';
+import { X, Copy, Palette, Type, Move, MoreVertical, Clock, Tag } from 'lucide-react';
 import type { Note } from './StickyNotesBoard';
 
 interface StickyNoteProps {
@@ -196,25 +196,34 @@ export function StickyNote({
                     onContextMenu={handleContextMenu}
                 >
                     {/* Note Header */}
-                    <div className="drag-handle flex items-center justify-between p-2 cursor-move bg-black/5 rounded-t-lg">
-                        <div className="flex items-center space-x-1">
-                            <Move className="h-3 w-3 text-gray-600" />
-                            <span className="text-xs text-gray-600 font-medium">Note</span>
+                    <div className="drag-handle flex items-center justify-between p-2 cursor-move bg-black/5 rounded-t-lg text-xs text-gray-600">
+                        <div className="flex items-center space-x-1 overflow-hidden">
+                            <Move className="h-3 w-3 text-gray-600 flex-shrink-0" />
+                            <span className="font-medium truncate" title={note.category || 'Note'}>
+                                {note.category || 'Note'}
+                            </span>
+                            {note.category && <Tag className="h-3 w-3 text-gray-500 flex-shrink-0" />}
                         </div>
                         <div className="flex items-center space-x-1">
-                            {isSelected && (
-                                <div className="flex items-center space-x-1">
-                                    <button
-                                        onClick={(e) => {
-                                            e.stopPropagation();
-                                            onDuplicate(note.id);
-                                        }}
-                                        className="p-1 hover:bg-black/10 rounded text-gray-600 hover:text-gray-800 transition-colors"
-                                        title="Duplicate"
-                                    >
-                                        <Copy className="h-3 w-3" />
-                                    </button>
+                            {note.reminderAt && (
+                                <div className="flex items-center space-x-0.5 text-blue-600" title={`Reminder: ${new Date(note.reminderAt).toLocaleString()}`}>
+                                    <Clock className="h-3 w-3" />
+                                    <span className="text-xs">
+                                        {new Date(note.reminderAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                                    </span>
                                 </div>
+                            )}
+                            {isSelected && (
+                                <button
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onDuplicate(note.id);
+                                    }}
+                                    className="p-1 hover:bg-black/10 rounded text-gray-600 hover:text-gray-800 transition-colors"
+                                    title="Duplicate"
+                                >
+                                    <Copy className="h-3 w-3" />
+                                </button>
                             )}
                             <button
                                 onClick={(e) => {
@@ -230,7 +239,7 @@ export function StickyNote({
                     </div>
 
                     {/* Note Content */}
-                    <div className="p-3 h-full">
+                    <div className="p-3 h-full"> {/* Adjusted height calculation might be needed if header grows */}
                         {isEditing ? (
                             <textarea
                                 ref={textareaRef}

--- a/front-end/components/StickyNotesBoard.tsx
+++ b/front-end/components/StickyNotesBoard.tsx
@@ -18,6 +18,8 @@ export interface Note {
     fontFamily: string;
     createdAt: Date;
     updatedAt: Date;
+    reminderAt?: string | null;
+    category?: string | null;
 }
 
 const COLORS = [
@@ -60,6 +62,8 @@ export function StickyNotesBoard() {
             fontFamily: FONT_FAMILIES[0],
             createdAt: new Date(),
             updatedAt: new Date(),
+            reminderAt: null,
+            category: null,
         };
 
         setNotes((prev) => [...prev, newNote]);
@@ -322,6 +326,33 @@ export function StickyNotesBoard() {
                             <option value="Monaco, monospace">Monospace</option>
                             <option value="Comic Sans MS, cursive">Comic Sans</option>
                         </select>
+
+                        {/* Category Input */}
+                        <label htmlFor="category-input" className="sr-only">Category</label>
+                        <input
+                            id="category-input"
+                            type="text"
+                            placeholder="Category"
+                            value={selectedNote.category || ''}
+                            onChange={(e) =>
+                                updateNote(selectedNote.id, { category: e.target.value || null })
+                            }
+                            className="px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                            aria-label="Set category for the note"
+                        />
+
+                        {/* Reminder Input */}
+                        <label htmlFor="reminder-input" className="sr-only">Reminder</label>
+                        <input
+                            id="reminder-input"
+                            type="datetime-local"
+                            value={selectedNote.reminderAt ? selectedNote.reminderAt.substring(0, 16) : ''} // Format for datetime-local
+                            onChange={(e) =>
+                                updateNote(selectedNote.id, { reminderAt: e.target.value ? new Date(e.target.value).toISOString() : null })
+                            }
+                            className="px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                            aria-label="Set reminder date and time for the note"
+                        />
 
                         <div className="flex-1"></div>
 


### PR DESCRIPTION
Adds category and reminder_at fields to sticky notes.

- Updates frontend Note interface and components (StickyNote, StickyNotesBoard) to allow users to set, view, and edit categories and reminders.
- Category is displayed in the note header.
- Reminder time is displayed with a clock icon if set.
- Backend API already supported these fields in the StickyNote model and controller.